### PR TITLE
Transpose based on EXIF orientation

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -119,7 +119,7 @@ class Avatar(models.Model):
         try:
             orig = self.avatar.storage.open(self.avatar.name, 'rb')
             image = Image.open(orig)
-            image = self.tanspose_image(image)
+            image = self.transpose_image(image)
             quality = quality or settings.AVATAR_THUMB_QUALITY
             w, h = image.size
             if w != size or h != size:

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -88,12 +88,38 @@ class Avatar(models.Model):
     def thumbnail_exists(self, size):
         return self.avatar.storage.exists(self.avatar_name(size))
 
+    def transpose_image(self, image):
+        """
+            Transpose based on EXIF information.
+            Borrowed from django-imagekit:
+            imagekit.processors.Transpose
+        """
+        EXIF_ORIENTATION_STEPS = {
+            1: [],
+            2: ['FLIP_LEFT_RIGHT'],
+            3: ['ROTATE_180'],
+            4: ['FLIP_TOP_BOTTOM'],
+            5: ['ROTATE_270', 'FLIP_LEFT_RIGHT'],
+            6: ['ROTATE_270'],
+            7: ['ROTATE_90', 'FLIP_LEFT_RIGHT'],
+            8: ['ROTATE_90'],
+        }
+        try:
+            orientation = image._getexif()[0x0112]
+            ops = EXIF_ORIENTATION_STEPS[orientation]
+        except:
+            ops = []
+        for method in ops:
+            image = image.transpose(getattr(Image, method))
+        return image
+
     def create_thumbnail(self, size, quality=None):
         # invalidate the cache of the thumbnail with the given size first
         invalidate_cache(self.user, size)
         try:
             orig = self.avatar.storage.open(self.avatar.name, 'rb')
             image = Image.open(orig)
+            image = self.tanspose_image(image)
             quality = quality or settings.AVATAR_THUMB_QUALITY
             w, h = image.size
             if w != size or h != size:

--- a/avatar/views.py
+++ b/avatar/views.py
@@ -1,3 +1,8 @@
+#coding=utf-8
+
+import os
+import uuid
+
 from django.http import Http404
 from django.shortcuts import render, redirect
 from django.utils import six
@@ -69,7 +74,13 @@ def add(request, extra_context=None, next_override=None,
         if upload_avatar_form.is_valid():
             avatar = Avatar(user=request.user, primary=True)
             image_file = request.FILES['avatar']
-            avatar.avatar.save(image_file.name, image_file)
+            
+            filename_parts = os.path.splitext(image_file.name)
+            extension = filename_parts[1]
+            filename = u'%s%s' % (unicode(uuid.uuid4()), unicode(extension))
+            #filename = image_file.name
+            
+            avatar.avatar.save(filename, image_file)
             avatar.save()
             messages.success(request, _("Successfully uploaded a new avatar."))
             avatar_updated.send(sender=Avatar, user=request.user, avatar=avatar)


### PR DESCRIPTION
Transpose the original image before resizing based on EXIF orientation
information to display image in the correct orientation. If someone
uploads an image from an iPhone (for example) the image is currently
often rendered in the wrong orientation.
