### PR TITLE
`EXPOSE_USERNAMES` prevents sensitive information leakage

### DIFF
--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -24,6 +24,8 @@ class AvatarConf(AppConf):
     STORAGE = settings.DEFAULT_FILE_STORAGE
     CLEANUP_DELETED = False
     AUTO_GENERATE_SIZES = (DEFAULT_SIZE,)
+    FACEBOOK_BACKUP = False
+    FACEBOOK_GET_ID = None
 
     def configure_auto_generate_avatar_sizes(self, value):
         return value or getattr(settings, 'AVATAR_AUTO_GENERATE_SIZES',

--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -26,6 +26,7 @@ class AvatarConf(AppConf):
     AUTO_GENERATE_SIZES = (DEFAULT_SIZE,)
     FACEBOOK_BACKUP = False
     FACEBOOK_GET_ID = None
+    DISABLE_CACHE = False
 
     def configure_auto_generate_avatar_sizes(self, value):
         return value or getattr(settings, 'AVATAR_AUTO_GENERATE_SIZES',

--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -27,6 +27,7 @@ class AvatarConf(AppConf):
     FACEBOOK_BACKUP = False
     FACEBOOK_GET_ID = None
     DISABLE_CACHE = False
+    RANDOMIZE_HASHES = False
 
     def configure_auto_generate_avatar_sizes(self, value):
         return value or getattr(settings, 'AVATAR_AUTO_GENERATE_SIZES',

--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -18,6 +18,7 @@ class AvatarConf(AppConf):
     THUMB_QUALITY = 85
     HASH_FILENAMES = False
     HASH_USERDIRNAMES = False
+    EXPOSE_USERNAMES = True
     ALLOWED_FILE_EXTS = None
     CACHE_TIMEOUT = 60 * 60
     STORAGE = settings.DEFAULT_FILE_STORAGE

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -1,3 +1,4 @@
+import binascii
 import datetime
 import os
 import hashlib
@@ -47,7 +48,10 @@ def avatar_file_path(instance=None, filename=None, size=None, ext=None):
         # File doesn't exist yet
         if settings.AVATAR_HASH_FILENAMES:
             (root, ext) = os.path.splitext(filename)
-            filename = hashlib.md5(force_bytes(filename)).hexdigest()
+            if settings.AVATAR_RANDOMIZE_HASHES:
+                filename = binascii.hexlify(os.urandom(16)).decode('ascii')
+            else:
+                filename = hashlib.md5(force_bytes(filename)).hexdigest()
             filename = filename + ext
     if size:
         tmppath.extend(['resized', str(size)])

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -8,6 +8,7 @@ from django.core.files import File
 from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.utils.translation import ugettext as _
+from django.utils.encoding import force_text
 from django.utils import six
 from django.db.models import signals
 
@@ -26,10 +27,12 @@ avatar_storage = get_storage_class(settings.AVATAR_STORAGE)()
 def avatar_file_path(instance=None, filename=None, size=None, ext=None):
     tmppath = [settings.AVATAR_STORAGE_DIR]
     if settings.AVATAR_HASH_USERDIRNAMES:
-        tmp = hashlib.md5(get_username(instance.user)).hexdigest()
-        tmppath.extend([tmp[0], tmp[1], get_username(instance.user)])
-    else:
+        tmp = hashlib.md5(force_bytes(get_username(instance.user))).hexdigest()
+        tmppath.extend(tmp[0:2])
+    if settings.AVATAR_EXPOSE_USERNAMES:
         tmppath.append(get_username(instance.user))
+    else:
+        tmppath.append(force_text(instance.user.pk))
     if not filename:
         # Filename already stored in database
         filename = instance.avatar.name

--- a/avatar/util.py
+++ b/avatar/util.py
@@ -64,6 +64,12 @@ def cache_result(default_size=settings.AVATAR_DEFAULT_SIZE):
     Decorator to cache the result of functions that take a ``user`` and a
     ``size`` value.
     """
+
+    if settings.AVATAR_DISABLE_CACHE:
+        def decorator(func):
+            return func
+        return decorator
+
     def decorator(func):
         def cached_func(user, size=None):
             prefix = func.__name__


### PR DESCRIPTION
username field is often replaced with email in custom user models, so we need an option not to expose email in avatar urls. setting `EXPOSE_USERNAMES` to `False` changes username to primary key in directory names