### PR TITLE
added database-level enforcement of unique user+primary pair in Avatar model

### DIFF
--- a/avatar/migrations/0002_add_user_primary_unique_together.py
+++ b/avatar/migrations/0002_add_user_primary_unique_together.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('avatar', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='avatar',
+            unique_together=set([('user', 'primary')]),
+        ),
+    ]

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -72,6 +72,7 @@ class Avatar(models.Model):
 
     class Meta:
         app_label = 'avatar'
+        unique_together = ('user', 'primary')
 
     def __unicode__(self):
         return _(six.u('Avatar for %s')) % self.user


### PR DESCRIPTION
Uniqueness of `user` and `primary` is happening in the `save()` method, but since there are ways to bypass the `save()` I thought adding this could be a helpful safety net.