### PR TITLE
Fix for django >= 1.10

### DIFF
--- a/avatar/management/commands/rebuild_avatars.py
+++ b/avatar/management/commands/rebuild_avatars.py
@@ -1,14 +1,14 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from avatar.conf import settings
 from avatar.models import Avatar
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = ("Regenerates avatar thumbnails for the sizes specified in "
             "settings.AVATAR_AUTO_GENERATE_SIZES.")
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         for avatar in Avatar.objects.all():
             for size in settings.AVATAR_AUTO_GENERATE_SIZES:
                 if options['verbosity'] != 0:


### PR DESCRIPTION
The class django.core.management.NoArgsCommand is removed.