### PR TITLE
Make alt attribute in avatar templatetag overridable.

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -59,6 +59,7 @@ def avatar_path_handler(instance=None, filename=None, size=None, ext=None):
     tmppath.append(os.path.basename(filename))
     return os.path.join(*tmppath)
 
+
 avatar_file_path = import_string(settings.AVATAR_PATH_HANDLER)
 
 

--- a/avatar/templates/avatar/avatar_tag.html
+++ b/avatar/templates/avatar/avatar_tag.html
@@ -1,1 +1,1 @@
-<img src="{{ url }}" alt="{{ alt }}" width="{{ size }}" height="{{ size }}" {% for key, value in kwargs.items %}{{key}}="{{value}}" {% endfor %}/>
+<img src="{{ url }}" width="{{ size }}" height="{{ size }}" {% for key, value in kwargs.items %}{{key}}="{{value}}" {% endfor %}/>

--- a/avatar/templatetags/avatar_tags.py
+++ b/avatar/templatetags/avatar_tags.py
@@ -42,10 +42,11 @@ def avatar(user, size=settings.AVATAR_DEFAULT_SIZE, **kwargs):
     else:
         alt = six.text_type(user)
         url = avatar_url(user, size)
+    kwargs.update({'alt': alt})
+
     context = {
         'user': user,
         'url': url,
-        'alt': alt,
         'size': size,
         'kwargs': kwargs,
     }

--- a/avatar/utils.py
+++ b/avatar/utils.py
@@ -57,13 +57,13 @@ def cache_result(default_size=settings.AVATAR_DEFAULT_SIZE):
         return decorator
 
     def decorator(func):
-        def cached_func(user, size=None):
+        def cached_func(user, size=None, **kwargs):
             prefix = func.__name__
             cached_funcs.add(prefix)
             key = get_cache_key(user, size or default_size, prefix=prefix)
             result = cache.get(key)
             if result is None:
-                result = func(user, size or default_size)
+                result = func(user, size or default_size, **kwargs)
                 cache_set(key, result)
             return result
         return cached_func

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -215,9 +215,8 @@ class AvatarTests(TestCase):
         avatar = get_primary_avatar(self.user)
 
         result = avatar_tags.avatar(self.user, title="Avatar")
-
-        self.assertIn('<img src="{}"'.format(avatar.avatar_url(80)), result)
-        self.assertIn('width="80" height="80" alt="test" title="Avatar" />', result)
+        html = '<img src="{}" width="80" height="80" alt="test" title="Avatar" />'.format(avatar.avatar_url(80))
+        self.assertInHTML(html, result)
 
     def test_default_add_template(self):
         response = self.client.get('/avatar/add/')
@@ -251,7 +250,7 @@ class AvatarTests(TestCase):
         response = self.client.get('/avatar/delete/')
         self.assertNotContains(response, 'like to delete.')
         self.assertContains(response, 'ALTERNATE DELETE TEMPLATE')
-    
+
     # def testAvatarOrder
     # def testReplaceAvatarWhenMaxIsOne
     # def testHashFileName

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -210,6 +210,15 @@ class AvatarTests(TestCase):
         self.assertIn('<img src="{}"'.format(avatar.avatar_url(100)), result)
         self.assertIn('alt="test" width="100" height="100" />', result)
 
+    def test_avatar_tag_works_with_kwargs(self):
+        upload_helper(self, "test.png")
+        avatar = get_primary_avatar(self.user)
+
+        result = avatar_tags.avatar(self.user, title="Avatar")
+
+        self.assertIn('<img src="{}"'.format(avatar.avatar_url(80)), result)
+        self.assertIn('width="80" height="80" alt="test" title="Avatar" />', result)
+
     def test_default_add_template(self):
         response = self.client.get('/avatar/add/')
         self.assertContains(response, 'Upload New Image')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -190,7 +190,7 @@ class AvatarTests(TestCase):
         result = avatar_tags.avatar(self.user.username)
 
         self.assertIn('<img src="{}"'.format(avatar.avatar_url(80)), result)
-        self.assertIn('alt="test" width="80" height="80" />', result)
+        self.assertIn('width="80" height="80" alt="test" />', result)
 
     def test_avatar_tag_works_with_user(self):
         upload_helper(self, "test.png")
@@ -199,7 +199,7 @@ class AvatarTests(TestCase):
         result = avatar_tags.avatar(self.user)
 
         self.assertIn('<img src="{}"'.format(avatar.avatar_url(80)), result)
-        self.assertIn('alt="test" width="80" height="80" />', result)
+        self.assertIn('width="80" height="80" alt="test" />', result)
 
     def test_avatar_tag_works_with_custom_size(self):
         upload_helper(self, "test.png")
@@ -208,7 +208,7 @@ class AvatarTests(TestCase):
         result = avatar_tags.avatar(self.user, 100)
 
         self.assertIn('<img src="{}"'.format(avatar.avatar_url(100)), result)
-        self.assertIn('alt="test" width="100" height="100" />', result)
+        self.assertIn('width="100" height="100" alt="test" />', result)
 
     def test_avatar_tag_works_with_kwargs(self):
         upload_helper(self, "test.png")


### PR DESCRIPTION
Currently, the `alt` attribute generated with the `avatar` template tag is hardcoded as the user object representation. This commit makes it possible to override the `alt` attribute via `kwargs` to the template tag.

**This fixes a potential security risk as well:** if your user object representation (i.e. `User.__unicode__`) happens to include the user's email address because it is no longer exposed via the `<img>` tag's `alt` attribute.