### PR TITLE
Fix invalid translations

### DIFF
--- a/avatar/locale/fr/LC_MESSAGES/django.po
+++ b/avatar/locale/fr/LC_MESSAGES/django.po
@@ -117,8 +117,9 @@ msgid ""
 "\n"
 "http://%(current_site)s%(avatar_url)s\n"
 msgstr ""
-"<a href=\"%(user_url)s\">%(avatar_creator)s</a> a mis à jour son avatar <a "
-"href=\"%(avatar_url)s\">%(avatar)s</a>."
+"%(avatar_creator)s a mis à jour son avatar %(avatar)s\n"
+"\n"
+"http://%(current_site)s%(avatar_url)s\n"
 
 #: templates/notification/avatar_friend_updated/notice.html:2
 #, python-format

--- a/avatar/locale/ru/LC_MESSAGES/django.po
+++ b/avatar/locale/ru/LC_MESSAGES/django.po
@@ -121,8 +121,9 @@ msgid ""
 "\n"
 "http://%(current_site)s%(avatar_url)s\n"
 msgstr ""
-"<a href=\"%(user_url)s\">%(avatar_creator)s</a> обновил свои аватары <a href="
-"\"%(avatar_url)s\">%(avatar)s</a>."
+"%(avatar_creator)s обновил свои аватары %(avatar)s.\n"
+"\n"
+"http://%(current_site)s%(avatar_url)s\n"
 
 #: templates/notification/avatar_friend_updated/notice.html:2
 #, python-format


### PR DESCRIPTION
'msgid' and 'msgstr' entries do not both end with '\n' which is
mandatory according to specification from the 'msgfmt' manual:

```
The msgid and msgstr strings are studied and compared. It is considered
abnormal if one string starts or ends with a newline while the other
does not.
```

Besides all placeholders from the 'msgid' must be used in the 'mgstr'.