### PR TITLE
Support for Django 2

### DIFF
--- a/avatar/migrations/0001_initial.py
+++ b/avatar/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('primary', models.BooleanField(default=False)),
                 ('avatar', models.ImageField(storage=django.core.files.storage.FileSystemStorage(), max_length=1024, upload_to=avatar.models.avatar_file_path, blank=True)),
                 ('date_uploaded', models.DateTimeField(default=django.utils.timezone.now)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -90,7 +90,7 @@ class AvatarField(models.ImageField):
 class Avatar(models.Model):
     user = models.ForeignKey(
         getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
-        verbose_name=_("user"),
+        verbose_name=_("user"), on_delete=models.CASCADE,
     )
     primary = models.BooleanField(
         verbose_name=_("primary"),

--- a/avatar/templatetags/avatar_tags.py
+++ b/avatar/templatetags/avatar_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.utils import six
 from django.utils.translation import ugettext as _


### PR DESCRIPTION
Rename django.core.urlresolvers to django.urls was done in Django 1.10 
This pull request is incompatible with older version