### PR TITLE
use the lazy version of gettext for translating models

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -9,7 +9,7 @@ from django.core.files import File
 from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import force_text
 from django.utils import six
 from django.db.models import signals


### PR DESCRIPTION
This PR fixes #167

The change is very small - now importing `ugettext_lazy` instead of `ugettext` in `models.py`

This has the effect of making django ignore localization of avatar related strings for database migration purposes, effectively negating the need to generate (and keep) custom migrations files for localized apps)