### PR TITLE
Make Django 3.2 compatible

### DIFF
--- a/avatar/apps.py
+++ b/avatar/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = 'avatar'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
If you don't specify the autofield type, you see a warning on every run.

@grantmcconnaughey Please let me know if you read this or if I need to try to get a hold of a maintainer some other way.