### PR TITLE
Django 4.0: ugettext_lazy -> gettext_lazy

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -9,7 +9,7 @@ from django.core.files import File
 from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.encoding import force_text
 from django.db.models import signals
 


### PR DESCRIPTION
ugettext_lazy` was deprecated in v2.2 and no longer used in django v3
https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0